### PR TITLE
init commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude terraform.tfvars as it might contain sensitive data, but include example.tfvars
+terraform.tfvars
+*.tfvars.json
+!example.tfvars
+
+# Ignore override files as they are usually used for local development
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore lock files
+.terraform.lock.hcl
+
+# Ignore plan output files
+tfplan
+*.tfplan
+
+# Ignore Mac system files
+.DS_Store
+
+# Ignore editor and IDE files
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
 # terraform-aws-gha-oidc
-Terraform gha oidc
+
+Terraform configuration for setting up GitHub Actions OIDC authentication with AWS.
+
+## Overview
+
+This Terraform configuration creates the necessary AWS IAM resources to enable GitHub Actions workflows to authenticate with AWS using OpenID Connect (OIDC). This approach eliminates the need for storing long-lived AWS credentials as GitHub secrets.
+
+## What it creates
+
+- An AWS IAM OIDC provider for GitHub Actions
+- An IAM role with a trust relationship to the OIDC provider
+- Policy attachments to grant permissions to the role
+
+## Usage
+
+1. Clone this repository
+2. Adjust `terraform.tfvars` if needed (it's configured for HeroesOTCrown org)
+3. Initialize and apply the Terraform configuration:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+4. After applying, note the role ARN from the output:
+
+```
+github_actions_role_arn = "arn:aws:iam::123456789012:role/gha-oidc-role"
+```
+
+5. Add this role ARN as a secret in your GitHub repository:
+   - Secret name: `AWS_ROLE_ARN`
+   - Secret value: The ARN from the output
+
+## GitHub Actions Workflow Example
+
+After deploying this configuration, use the following GitHub Actions workflow to authenticate with AWS:
+
+```yaml
+name: AWS Deployment with OIDC
+
+on:
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# These permissions are needed for OIDC with AWS
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read   # Required to checkout the repository
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      
+      - name: Verify AWS access
+        run: |
+          aws sts get-caller-identity
+```
+
+## Configuration Details
+
+The current configuration allows:
+- GitHub Actions from all repositories in the HeroesOTCrown organization
+- Administrator access to AWS
+
+You can modify `terraform.tfvars` to adjust:
+- Which GitHub repositories can assume the role
+- What permissions the role has
+- Tags applied to AWS resources
+
+
+## License
+
+MIT

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,43 @@
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  tags            = var.tags
+}
+
+resource "aws_iam_role" "github_actions" {
+  name               = "gha-oidc-role"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role_policy.json
+  description        = "IAM Role for GitHub Actions OIDC"
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = var.allowed_repository_strings
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_policy_attachment" {
+  count      = length(var.policy_arns)
+  role       = aws_iam_role.github_actions.name
+  policy_arn = var.policy_arns[count.index]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,14 @@
+output "github_actions_oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC Provider"
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+}
+
+output "github_actions_role_arn" {
+  description = "ARN of the IAM role for GitHub Actions"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "github_actions_role_name" {
+  description = "Name of the IAM role for GitHub Actions"
+  value       = aws_iam_role.github_actions.name
+}

--- a/policies.tf
+++ b/policies.tf
@@ -1,0 +1,55 @@
+# Optional: Create a custom IAM policy for GitHub Actions
+# Uncomment and modify as needed
+
+/*
+resource "aws_iam_policy" "github_actions_custom_policy" {
+  name        = "github-actions-deployment-policy"
+  description = "Custom policy for GitHub Actions deployments"
+  
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket",
+          "s3:DeleteObject"
+        ],
+        Resource = [
+          "arn:aws:s3:::your-deployment-bucket",
+          "arn:aws:s3:::your-deployment-bucket/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation",
+          "cloudfront:ListInvalidations"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload"
+        ],
+        Resource = "arn:aws:ecr:*:*:repository/your-ecr-repo"
+      }
+    ]
+  })
+}
+
+# To use this custom policy, add its ARN to the policy_arns variable in terraform.tfvars:
+# policy_arns = [
+#   aws_iam_policy.github_actions_custom_policy.arn
+# ]
+*/

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,30 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "iam_role_name" {
+  description = "Name of the IAM role to be created for GitHub Actions"
+  type        = string
+  default     = "github-actions-oidc-role"
+}
+
+variable "allowed_repository_strings" {
+  description = "List of GitHub repository patterns allowed to assume the role"
+  type        = list(string)
+}
+
+variable "policy_arns" {
+  description = "List of IAM Policy ARNs to attach to the role"
+  type        = list(string)
+
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {
+    ManagedBy = "terraform"
+  }
+}


### PR DESCRIPTION
This pull request includes significant changes to the Terraform configuration for setting up GitHub Actions OIDC authentication with AWS. The most important changes involve creating necessary IAM resources, updating documentation, and adding configuration options.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R88): Expanded the README to include an overview, usage instructions, a GitHub Actions workflow example, and configuration details.

IAM resources creation:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR1-R43): Added resources for creating an AWS IAM OIDC provider, an IAM role with a trust relationship to the OIDC provider, and role policy attachments.

Output variables:

* [`outputs.tf`](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R1-R14): Added output variables for the ARN and name of the created IAM role and OIDC provider.

Optional custom policy:

* [`policies.tf`](diffhunk://#diff-485343ba546afa4cd9be389fda4e3d58e7aa36b57dabf273c04e7d8c772c9e0fR1-R55): Added an optional section for creating a custom IAM policy for GitHub Actions, which can be uncommented and modified as needed.

Terraform configuration:

* [`terraform.tf`](diffhunk://#diff-ae3037560f46b85279fe53ff13896a24529afd8ffccd0911dfa366d0a4db9ec2R1-R13): Specified required providers and versions for the Terraform configuration.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR1-R30): Added variables for AWS region, IAM role name, allowed repository patterns, policy ARNs, and resource tags.